### PR TITLE
fix macOS builds

### DIFF
--- a/include/PR/ultratypes.h
+++ b/include/PR/ultratypes.h
@@ -57,6 +57,9 @@ typedef volatile long long          vs64;   /* signed 64-bit */
 typedef float   f32;    /* single prec floating point */
 typedef double  f64;    /* double prec floating point */
 
+#ifdef TARGET_DC
+#include <stddef.h>
+#else
 #if !defined(_SIZE_T) && !defined(_SIZE_T_) && !defined(_SIZE_T_DEF)
 #define _SIZE_T
 #define _SIZE_T_DEF         /* exeGCC size_t define label */
@@ -65,6 +68,7 @@ typedef unsigned int    size_t;
 #endif
 #if (_MIPS_SZLONG == 64)
 typedef unsigned long   size_t;
+#endif
 #endif
 #endif
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -67,7 +67,7 @@ dkr_assets_tool_C_FILES := $(call rwildcard,dkr_assets_tool_src,*.c)
 dkr_assets_tool_OBJ_FILES := $(foreach file,$(dkr_assets_tool_C_FILES),$(BUILD_DIR)/$(file:.c=.o)) \
                              $(foreach file,$(dkr_assets_tool_CPP_FILES),$(BUILD_DIR)/$(file:.cpp=.o))
 
-DUMMY != mkdir -p $(sort $(dir $(dkr_assets_tool_OBJ_FILES)))
+DUMMY := $(shell mkdir -p $(sort $(dir $(dkr_assets_tool_OBJ_FILES))))
 
 $(BUILD_DIR)/%.o: %.c
 	$(CC) -c $^ -o $@ $(CFLAGS)


### PR DESCRIPTION
tools/Makefile: the != shell-assign operator needs GNU Make 4.0+, but macOS ships 3.81, so the _build dirs were never created. Use $(shell) which works everywhere.

ultratypes.h: hand-typedeffing size_t defines _SIZE_T, which stops the toolchain's stddef.h from defining _SIZE_T_DECLARED/__size_t — and newlib 4.6's strings.h needs those. On TARGET_DC, include <stddef.h> instead (same type, unsigned int on sh-elf). N64 and PC paths unchanged.