### PR TITLE
speed up asset loading over /pc/ with unbuffered stdio

### DIFF
--- a/dreamcast/reimpl.c
+++ b/dreamcast/reimpl.c
@@ -74,6 +74,9 @@ static u8 *pc_load_file(const char *path, u32 *sizeOut) {
         fprintf(stderr, "ASSETS: cannot open %s (run from the repo root, and build the N64 assets first)\n", path);
         exit(1);
     }
+    // Make file reading faster
+    setvbuf(f, NULL, _IONBF, 0);
+
     fseek(f, 0, SEEK_END);
     size = ftell(f);
     fseek(f, 0, SEEK_SET);


### PR DESCRIPTION
Over dcload every read() syscall is a full bulk-transfer round trip with ~6 ms of fixed overhead, and newlib stdio refills its 1 KB BUFSIZ buffer once per syscall — so the 10 MB assets.bin fread became ~10,100 tiny transactions (~0.16 MiB/s, 60+ s total).

An unbuffered FILE takes newlib fread's fast path instead: it reads straight into the destination buffer with a single full-size read() syscall, i.e. one bulk transaction for the whole blob.