### PR TITLE
GAINZ 2: Audio, light, collision, envmap, math.

### DIFF
--- a/dreamcast/audio.c
+++ b/dreamcast/audio.c
@@ -1,5 +1,5 @@
 #include <kos.h>
-#include <stddef.h> 
+#include <stddef.h>
 #include <dc/sound/stream.h>
 #include <stdio.h>
 #include <string.h>
@@ -21,7 +21,7 @@ extern void am_audio_frame_pc(void);
 extern unsigned int frameSize;
 
 #define DC_AUDIO_RATE 22050
-#define DC_AUDIO_BYTES_PER_SAMPLE 4 // stereo s16 (interleaved, as the manager sees it)
+#define DC_AUDIO_BYTES_PER_SAMPLE 4 // stereo s16 (planar per chunk; see osAiSetNextBuffer)
 
 // Runs on the audio thread only (dc_audio_thread): osAiSetNextBuffer,
 // osAiGetLength, pc_audio_tick, and the snd_stream direct callback (via
@@ -98,10 +98,11 @@ static void ring_read(int n, void *dst, u32 count) {
     }
     idx = r->tail & mask;
     first = MIN(count, r->cap - idx);
-    shz_memcpy(dst, r->buf + idx, first);
-    if (count - first) {
-        shz_memcpy((u8 *) dst + first, r->buf, count - first);
-    }
+
+    spu_memload_sq((uintptr_t)dst, r->buf + idx, first);
+    if(count - first)
+        spu_memload_sq((u8 *) dst + first, r->buf, count - first);
+
     r->tail += count;
 }
 
@@ -164,8 +165,8 @@ s32 osAiSetFrequency(u32 frequency) {
     return (s32) DC_AUDIO_RATE;
 }
 
-// The game passes the previous frame's mixed PCM: interleaved stereo s16.
-// Deinterleave into the two channel rings and account the byte count for pacing.
+#define DC_AUDIO_CHUNK_SAMPLES 160
+
 void osAiSetNextBuffer(void *buf, u32 size) {
     if (!sReady || size == 0) {
         return;
@@ -174,23 +175,19 @@ void osAiSetNextBuffer(void *buf, u32 size) {
     sQueued += size; // pacing signal — see osAiGetLength()
 
     if (sAudioOk && buf != NULL) {
-        const s16 *pcm = (const s16 *) buf;
-        u32 frames = size / DC_AUDIO_BYTES_PER_SAMPLE; // stereo sample pairs
+        const s16 *p = (const s16 *) buf;
+        u32 frames = size / DC_AUDIO_BYTES_PER_SAMPLE; // samples per channel, whole frame
         u32 done = 0;
 
-        // Deinterleave in bounded chunks so the scratch stays on the stack.
         while (done < frames) {
-            s16 l[256];
-            s16 r[256];
-            u32 n = MIN(frames - done, 256u);
-            u32 i;
+            u32 n = MIN(frames - done, (u32) DC_AUDIO_CHUNK_SAMPLES);
+            const s16 *l = p;
+            const s16 *r = p + n;
 
-            for (i = 0; i < n; i++) {
-                l[i] = pcm[(done + i) * 2 + 0];
-                r[i] = pcm[(done + i) * 2 + 1];
-            }
             ring_write(0, l, n * sizeof(s16));
             ring_write(1, r, n * sizeof(s16));
+
+            p += (u32) n << 1; // this chunk's full L+R block
             done += n;
         }
 
@@ -332,7 +329,7 @@ void dc_audio_start_thread(void) {
     vblank_handler_add(&audio_vblank_handler, NULL);
 
     attr.create_detached = 1;
-    attr.stack_size = 32768;
+    attr.stack_size = 8192;
     attr.stack_ptr = NULL;
     attr.prio = 2; // high (low number = high priority in KOS)
     attr.label = "audio";

--- a/dreamcast/audio_hle.c
+++ b/dreamcast/audio_hle.c
@@ -62,16 +62,17 @@ static struct {
 
     alignas(32) float tableF[8][2][8];
     alignas(32) s16 table[512]; // ADPCM codebook, also POLEF coefficients
-
 } rspa;
 
 // Identity "physical" addresses: osVirtualToPhysical is identity on the host, so a
 // DMA address in the command list is just a host pointer.
-static void *rdram(u32 addr) {
+SHZ_FORCE_INLINE
+void *rdram(u32 addr) {
     return (void *) (unsigned long) addr;
 }
 
-static s16 clamp16(s32 v) {
+SHZ_FORCE_INLINE
+s16 clamp16(s32 v) {
     if (v > 32767) {
         return 32767;
     }
@@ -81,7 +82,8 @@ static s16 clamp16(s32 v) {
     return (s16) v;
 }
 
-static s16 clamp16f(float v) {
+SHZ_FORCE_INLINE
+s16 clamp16f(float v) {
     if (v < -32768.0f) {
         return -32768;
     }
@@ -89,6 +91,21 @@ static s16 clamp16f(float v) {
         return 32767;
     }
     return (s16) v;
+}
+
+SHZ_FORCE_INLINE
+float fclamp16f(float v, s16* res) {
+    float f;
+
+    if (v < -32768.0f)
+        f = -32768.0f;
+    else if (v > 32767.0f)
+        f = 32767.0f;
+    else
+        f = v;
+
+    *res = (s16)f;
+    return f;
 }
 
 // DMEM is byte-addressed but every audio buffer in it is s16-aligned.
@@ -251,55 +268,18 @@ static void op_mix(u32 w0, u32 w1) {
     }
 }
 
-// A_INTERLEAVE: weave two mono buffers into stereo at `out`. Writes 2*count bytes
-// (alSavePull sets count to the MONO byte count, then re-sets it to count<<2 before
-// the SAVEBUFF that follows).
-SHZ_NO_UNROLL_LOOPS
+// We no longer interleave shit, cuz the AICA would just
+// make us deinterleave it.
 static void op_interleave(u32 w1) {
     u16 rightAddr = w1 & 0xFFFF;
-    const s16 *r = dmem16(rightAddr);
-    SHZ_PREFETCH(r);
-
     u16 leftAddr = (w1 >> 16) & 0xFFFF;
+    const s16 *r = dmem16(rightAddr);
     const s16 *l = dmem16(leftAddr);
-    u32 *dst = (u32 *) dmem16(rspa.out);
-    s32 n = rspa.count >> 1; // samples per channel
-    s32 k;
+    s16 *dst = dmem16(rspa.out);
+    s32 n = rspa.count >> 1; // samples per channel, this chunk only
 
-    for (k = 0; k < n; k += 8) {
-        SHZ_PREFETCH(l);
-        u32 lr0 = (u32) (u16) r[0] << 16;
-        u32 lr1 = (u32) (u16) r[1] << 16;
-        u32 lr2 = (u32) (u16) r[2] << 16;
-        u32 lr3 = (u32) (u16) r[3] << 16;
-        u32 lr4 = (u32) (u16) r[4] << 16;
-        u32 lr5 = (u32) (u16) r[5] << 16;
-        u32 lr6 = (u32) (u16) r[6] << 16;
-        u32 lr7 = (u32) (u16) r[7] << 16;
-        r += 8;
-
-        SHZ_PREFETCH(dst);
-        lr0 |= (u16) l[0];
-        lr1 |= (u16) l[1];
-        lr2 |= (u16) l[2];
-        lr3 |= (u16) l[3];
-        lr4 |= (u16) l[4];
-        lr5 |= (u16) l[5];
-        lr6 |= (u16) l[6];
-        lr7 |= (u16) l[7];
-        l += 8;
-
-        SHZ_PREFETCH(r);
-        dst[0] = lr0;
-        dst[1] = lr1;
-        dst[2] = lr2;
-        dst[3] = lr3;
-        dst[4] = lr4;
-        dst[5] = lr5;
-        dst[6] = lr6;
-        dst[7] = lr7;
-        dst += 8;
-    }
+    shz_memcpy(dst, l, n * sizeof(s16));
+    shz_memcpy(dst + n, r, n * sizeof(s16));
 }
 
 alignas(32) static const float sResampleTable[64][4] = {
@@ -720,7 +700,8 @@ static void op_adpcm(u32 w0, u32 w1) {
 //   [6..7] rate L (16.16)      [8..9] rate R
 //   [10]   dry                 [11]   wet
 // ---------------------------------------------------------------------------
-static void ramp_update(s32 *volAccu, const s32 *target, const s32 *rate) {
+SHZ_FORCE_INLINE
+void ramp_update(s32 *volAccu, const s32 *target, const s32 *rate) {
     s32 i;
 
     for (i = 0; i < 2; i++) {
@@ -745,7 +726,6 @@ static void op_envmixer(u32 w0, u32 w1) {
     s32 n = rspa.count >> 1;
     s32 volAccu[2];
     s32 target[2], rate[2], dry, wet;
-    s32 k;
 
     if (flags & A_INIT) {
         volAccu[0] = (s32) rspa.vol[0] << 16;
@@ -767,8 +747,72 @@ static void op_envmixer(u32 w0, u32 w1) {
         wet = state[11];
     }
 
-    if (flags & A_AUX) {
-        for (k = 0; k < n; k++) {
+    SHZ_PREFETCH(src);
+
+    if (rate[0] == 0 && rate[1] == 0) {
+        const s32 vl = volAccu[0] >> 16;
+        const s32 vr = volAccu[1] >> 16;
+
+        if (flags & A_AUX) {
+#pragma GCC unroll 1
+            for (int k = 0; k < (n >> 1); ++k) {
+                SHZ_PREFETCH(dryL);
+                s32 s1 = *src++;
+                s32 s2 = *src++;
+
+                s32 l1 = (s1 * vl) >> 15;
+                s32 l2 = (s2 * vl) >> 15;
+
+                s32 r1 = (s1 * vr) >> 15;
+                s32 r2 = (s2 * vr) >> 15;
+
+                SHZ_PREFETCH(dryR);
+                dryL[0] = clamp16(dryL[0] + ((l1 * dry) >> 15));
+                dryL[1] = clamp16(dryL[1] + ((l2 * dry) >> 15));
+                dryL += 2;
+
+                SHZ_PREFETCH(wetL);
+                dryR[0] = clamp16(dryR[0] + ((r1 * dry) >> 15));
+                dryR[1] = clamp16(dryR[1] + ((r2 * dry) >> 15));
+                dryR += 2;
+
+                SHZ_PREFETCH(wetR);
+                wetL[0] = clamp16(wetL[0] + ((l1 * wet) >> 15));
+                wetL[1] = clamp16(wetL[1] + ((l2 * wet) >> 15));
+                wetL += 2;
+
+                SHZ_PREFETCH(src);
+                wetR[0] = clamp16(wetR[0] + ((r1 * wet) >> 15));
+                wetR[1] = clamp16(wetR[1] + ((r2 * wet) >> 15));
+                wetR += 2;
+            }
+        } else {
+#pragma GCC unroll 1
+            for (int k = 0; k < (n >> 1); ++k) {
+                SHZ_PREFETCH(dryL);
+                s32 s1 = *src++;
+                s32 s2 = *src++;
+
+                s32 l1 = (s1 * vl) >> 15;
+                s32 l2 = (s2 * vl) >> 15;
+
+                s32 r1 = (s1 * vr) >> 15;
+                s32 r2 = (s2 * vr) >> 15;
+
+                SHZ_PREFETCH(dryR);
+                dryL[0] = clamp16(dryL[0] + ((l1 * dry) >> 15));
+                dryL[1] = clamp16(dryL[1] + ((l2 * dry) >> 15));
+                dryL += 2;
+
+                SHZ_PREFETCH(src);
+                dryR[0] = clamp16(dryR[0] + ((r1 * dry) >> 15));
+                dryR[1] = clamp16(dryR[1] + ((r2 * dry) >> 15));
+                dryR += 2;
+            }
+        }
+    } else if (flags & A_AUX) {
+#pragma GCC unroll 2
+        for (int k = 0; k < n; k++) {
             s32 s = src[k];
             s32 vl = volAccu[0] >> 16;
             s32 vr = volAccu[1] >> 16;
@@ -783,7 +827,8 @@ static void op_envmixer(u32 w0, u32 w1) {
             ramp_update(volAccu, target, rate);
         }
     } else {
-        for (k = 0; k < n; k++) {
+#pragma GCC unroll 2
+        for (int k = 0; k < n; k++) {
             s32 s = src[k];
             s32 vl = volAccu[0] >> 16;
             s32 vr = volAccu[1] >> 16;
@@ -820,31 +865,61 @@ static void op_envmixer(u32 w0, u32 w1) {
 // is exactly the one-pole recursion y[n] = gain·x[n] + fc·y[n-1]. Implement that
 // directly. Everything is Q14 (SCALE = 16384 in drvrnew.c; fgain = SCALE - fc, so
 // DC gain is unity).
+SHZ_COLD
 static void op_polef(u32 w0, u32 w1) {
-    u8 flags = (w0 >> 16) & 0xFF;
-    s16 gain = (s16) (w0 & 0xFFFF);
-    s16 *state = rdram(w1);
     s16 *src = dmem16(rspa.in);
-    s16 *dst = dmem16(rspa.out);
-    s32 fc = rspa.table[8];
-    s32 n = rspa.count >> 1;
-    s32 y1;
-    s32 k;
+    SHZ_PREFETCH(src);
 
-    if (flags & A_INIT) {
-        y1 = 0;
-    } else {
-        y1 = state[0];
+    s16*    dst = dmem16(rspa.out);
+    s16*  state = rdram(w1);
+    u8    flags = (w0 >> 16) & 0xFF;
+    float  gain = (s16) (w0 & 0xFFFF);
+    float    fc = rspa.table[8];
+    int       n = rspa.count >> 3;
+    float    y0 = (flags & A_INIT)? 0.0f : state[0];
+
+    const float      A  = gain * (1.0f / 16384.0f);
+    const float      B  =   fc * (1.0f / 16384.0f);
+    const shz_vec4_t BV = shz_vec4_init(B, (B * B   ), (B * B * B), (B * B * B * B));
+    const shz_vec4_t AV = shz_vec4_init(A, (A * BV.x), (A * BV.y ), (A * BV.z     ));
+
+    shz_xmtrx_init_lower_triangular(AV, AV.xyz, AV.xy, AV.x);
+
+    for(int k = 0; k < n; ++k) {
+        SHZ_PREFETCH(dst);
+
+        const shz_vec4_t in   = shz_vec4_init(src[0], src[1], src[2], src[3]);
+        const shz_vec4_t part = shz_xmtrx_transform_vec4(in);
+              shz_vec4_t out  = shz_vec4_add(part, shz_vec4_scale(BV, y0));
+
+        SHZ_PREFETCH(src += 4);
+
+        if(out.x < -32768.0f || out.x > 32767.0f) goto y1;
+        *dst++ = (s16)out.x;
+
+        if(out.y < -32768.0f || out.y > 32767.0f) goto y2;
+        *dst++ = (s16)out.y;
+
+        if(out.z < -32768.0f || out.z > 32767.0f) goto y3;
+        *dst++ = (s16)out.z;
+
+        if(out.w < -32768.0f || out.w > 32767.0f) goto y4;
+        *dst++ = (s16)out.w;
+
+        y0 = out.w;
+        continue;
+
+    y1: out.x = fclamp16f((in.x * gain + fc *    y0) * (1.0f / 16384.0f), dst++);
+    y2: out.y = fclamp16f((in.y * gain + fc * out.x) * (1.0f / 16384.0f), dst++);
+    y3: out.z = fclamp16f((in.z * gain + fc * out.y) * (1.0f / 16384.0f), dst++);
+    y4: out.w = fclamp16f((in.w * gain + fc * out.z) * (1.0f / 16384.0f), dst++);
+        y0    = out.w;
     }
 
-    for (k = 0; k < n; k++) {
-        y1 = clamp16(((s32) src[k] * (s32) gain + fc * y1) >> 14);
-        dst[k] = (s16) y1;
-    }
-
-    state[0] = (s16) y1;
+    state[0] = (s16)y0;
     state[1] = 0;
 }
+
 
 // ---------------------------------------------------------------------------
 // The interpreter

--- a/src/audio.c
+++ b/src/audio.c
@@ -59,7 +59,7 @@ u8 gBlockVoiceLimitChange = FALSE;
 /************ .bss ************/
 
 // The audio heap is located at the start of the BSS section.
-u8 gAudioHeapStack[AUDIO_HEAP_SIZE];
+alignas(32) u8 gAudioHeapStack[AUDIO_HEAP_SIZE];
 
 ALHeap gALHeap;
 ALSeqFile *gSequenceTable;

--- a/src/hasm/collision.c
+++ b/src/hasm/collision.c
@@ -5,6 +5,10 @@
 #include "textures_sprites.h"
 #include "types.h"
 
+#ifdef TARGET_DC
+#   include <sh4zam/shz_sh4zam.h>
+#endif
+
 /*******************************/
 
 extern LevelModel *gCurrentLevelModel;
@@ -309,21 +313,30 @@ s32 resolve_collisions(Vec3f *origin, Vec3f *target, f32 *radius, s8 *surface, s
                     B = collisionPlanes[facet->basePlaneIndex * 4 + 1];
                     C = collisionPlanes[facet->basePlaneIndex * 4 + 2];
                     D = collisionPlanes[facet->basePlaneIndex * 4 + 3];
-
+#ifdef TARGET_DC
+                    shz_vec2_t dot = shz_vec4_dot2(shz_vec4_deref(&collisionPlanes[facet->basePlaneIndex * 4]),
+                                                   shz_vec3_vec4(shz_vec3_deref(target), 1.0f),
+                                                   shz_vec3_vec4(shz_vec3_deref(origin), 1.0f));
+                    targetDist = dot.x - *radius;
+                    originDist = dot.y - *radius;
+#else
                     targetDist = (target->x * A + target->y * B + target->z * C + D) - *radius;
                     originDist = (origin->x * A + origin->y * B + origin->z * C + D) - *radius;
-
+#endif
                     // Process only one-sided collisions (above -> below plane), with tolerance
                     if (targetDist < -0.1 && originDist >= -0.1) {
                         diffX = target->x - origin->x;
                         diffY = target->y - origin->y;
                         diffZ = target->z - origin->z;
-
-                        if (targetDist != originDist) {
+#ifdef TARGET_DC
+                        intersectionFactor = shz_divf_fsrra(originDist, originDist - targetDist);
+#else
+                       if (targetDist != originDist) {
                             intersectionFactor = originDist / (originDist - targetDist);
                         } else {
                             intersectionFactor = 0.0f;
                         }
+#endif
 
                         intersectionPointX = origin->x + diffX * intersectionFactor;
                         intersectionPointY = origin->y + diffY * intersectionFactor;
@@ -345,8 +358,12 @@ s32 resolve_collisions(Vec3f *origin, Vec3f *target, f32 *radius, s8 *surface, s
                             B1 = collisionPlanes[edgeBisectorPlane * 4 + 1];
                             C1 = collisionPlanes[edgeBisectorPlane * 4 + 2];
                             D1 = collisionPlanes[edgeBisectorPlane * 4 + 3];
-
+#ifdef TARGET_DC
+                            dist = shz_dot8f(intersectionPointX, intersectionPointY, intersectionPointZ, 1.0f,
+                                             A1,                 B1,                 C1,                 D1);
+#else
                             dist = intersectionPointX * A1 + intersectionPointY * B1 + intersectionPointZ * C1 + D1;
+#endif
                             if (flipSide) {
                                 dist = -dist;
                             }
@@ -361,7 +378,11 @@ s32 resolve_collisions(Vec3f *origin, Vec3f *target, f32 *radius, s8 *surface, s
                                 gCollisionMode == COLLISION_MODE_DEFAULT) {
                                 // Push up vertically if slope is gentle and not stone
                                 outX = target->x;
+#ifdef TARGET_DC
+                                outY = shz_divf_fsrra(*radius - (target->x * A + target->z * C + D), B);
+#else
                                 outY = (*radius - (target->x * A + target->z * C + D)) / B;
+#endif
                                 outZ = target->z;
                             } else {
                                 if (B < 0.45 && gCollisionMode != COLLISION_MODE_NO_WALLS) {
@@ -429,8 +450,12 @@ s32 resolve_collisions(Vec3f *origin, Vec3f *target, f32 *radius, s8 *surface, s
                     B = collisionPlanes[facet->basePlaneIndex * 4 + 1];
                     C = collisionPlanes[facet->basePlaneIndex * 4 + 2];
                     D = collisionPlanes[facet->basePlaneIndex * 4 + 3];
-
+#ifdef TARGET_DC
+                    targetDist = shz_dot8f(target->x, target->y, target->z, 1.0f,
+                                           A,         B,         C,         D) - *radius;
+#else
                     targetDist = (target->x * A + target->y * B + target->z * C + D) - *radius;
+#endif
                     if (targetDist < -0.1 && targetDist > -(*radius + 3.0f)) {
                         insideTriangle = TRUE;
                         for (j = 0; j < 3 && insideTriangle; j++) {
@@ -447,8 +472,12 @@ s32 resolve_collisions(Vec3f *origin, Vec3f *target, f32 *radius, s8 *surface, s
                             B1 = collisionPlanes[edgePlaneIndex * 4 + 1];
                             C1 = collisionPlanes[edgePlaneIndex * 4 + 2];
                             D1 = collisionPlanes[edgePlaneIndex * 4 + 3];
-
+#ifdef TARGET_DC
+                            dist = shz_dot8f(target->x, target->y, target->z, 1.0f,
+                                             A1,        B1,        C1,        D1);
+#else
                             dist = target->x * A1 + target->y * B1 + target->z * C1 + D1;
+#endif
                             if (flipSide) {
                                 dist = -dist;
                             }

--- a/src/hasm/math_util.c
+++ b/src/hasm/math_util.c
@@ -251,9 +251,16 @@ void mtxf_to_mtxs(MtxF *mf, MtxS *mi) {
  * Official name: mathMtxXFMF
  */
 void mtxf_transform_point(float mf[4][4], float x, float y, float z, float *ox, float *oy, float *oz) {
+#ifdef TARGET_DC
+    shz_vec3_t out = shz_mat4x4_transform_point3((const shz_mat4x4_t*)mf, shz_vec3_init(x, y, z));
+    *ox = out.x;
+    *oy = out.y;
+    *oz = out.z;
+#else
     *ox = mf[0][0] * x + mf[1][0] * y + mf[2][0] * z + mf[3][0];
     *oy = mf[0][1] * x + mf[1][1] * y + mf[2][1] * z + mf[3][1];
     *oz = mf[0][2] * x + mf[1][2] * y + mf[2][2] * z + mf[3][2];
+#endif
 }
 
 /**
@@ -264,12 +271,18 @@ void mtxf_transform_point(float mf[4][4], float x, float y, float z, float *ox, 
  * Official name: mathMtxFastXFMF
  */
 void mtxf_transform_dir(MtxF *mf, Vec3f *in, Vec3f *out) {
+#ifdef TARGET_DC
+    *(SHZ_ALIASING shz_vec3_t*)out =
+            shz_mat4x4_transform_vec3((const shz_mat4x4_t*)mf,
+                                       *(SHZ_ALIASING const shz_vec3_t*)in);
+#else
     f32 x = in->f[0];
     f32 y = in->f[1];
     f32 z = in->f[2];
     out->f[0] = (x * (*mf)[0][0]) + (y * (*mf)[1][0]) + (z * (*mf)[2][0]);
     out->f[1] = (x * (*mf)[0][1]) + (y * (*mf)[1][1]) + (z * (*mf)[2][1]);
     out->f[2] = (x * (*mf)[0][2]) + (y * (*mf)[1][2]) + (z * (*mf)[2][2]);
+#endif
 }
 
 /**
@@ -277,8 +290,12 @@ void mtxf_transform_dir(MtxF *mf, Vec3f *in, Vec3f *out) {
  * Official name: mathMtxCatF
  */
 void mtxf_mul(MtxF *mat1, MtxF *mat2, MtxF *output) {
+#ifdef TARGET_DC
+    shz_mat4x4_mult((shz_mat4x4_t*)output,
+                    (const shz_mat4x4_t*)mat2,
+                    (const shz_mat4x4_t*)mat1);
+#else
     s32 i, j, k;
-
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
             /*
@@ -292,6 +309,7 @@ void mtxf_mul(MtxF *mat1, MtxF *mat2, MtxF *output) {
                               ((*mat1)[i][0] * (*mat2)[0][j] + (*mat1)[i][3] * (*mat2)[3][j]);
         }
     }
+#endif
 }
 
 /**
@@ -422,6 +440,28 @@ void mtxs_transform_dir(MtxS *mi, Vec3s *vec) {
     vec->z = ((*mi)[0][2] * x + (*mi)[1][2] * y + (*mi)[2][2] * z) >> 16;
 }
 
+#ifdef TARGET_DC
+void xmtrx_init_transform(ObjectTransform *trans) {
+    shz_xmtrx_init_rotation_yxz(trans->rotation.y_rotation / SHZ_FSCA_RAD_FACTOR,
+                                trans->rotation.x_rotation / SHZ_FSCA_RAD_FACTOR,
+                                trans->rotation.z_rotation / SHZ_FSCA_RAD_FACTOR);
+    shz_xmtrx_apply_scale(trans->scale, trans->scale, trans->scale);
+    shz_xmtrx_set_translation(trans->x_position,
+                              trans->y_position,
+                              trans->z_position);
+}
+
+void xmtrx_apply_transform(ObjectTransform *trans) {
+    shz_xmtrx_apply_rotation_yxz(trans->rotation.y_rotation / SHZ_FSCA_RAD_FACTOR,
+                                trans->rotation.x_rotation / SHZ_FSCA_RAD_FACTOR,
+                                trans->rotation.z_rotation / SHZ_FSCA_RAD_FACTOR);
+    shz_xmtrx_apply_scale(trans->scale, trans->scale, trans->scale);
+    shz_xmtrx_set_translation(trans->x_position,
+                              trans->y_position,
+                              trans->z_position);
+}
+#endif
+
 /**
  * Converts an ObjectTransform into a transformation matrix and writes it to `mtx`.
  * The matrix is built by applying the following operations in order:
@@ -432,6 +472,10 @@ void mtxs_transform_dir(MtxS *mi, Vec3s *vec) {
  * 5. Translation
  */
 void mtxf_from_transform(MtxF *mtx, ObjectTransform *trans) {
+#ifdef TARGET_DC
+    xmtrx_init_transform(trans);
+    shz_xmtrx_store_4x4((shz_mat4x4_t*)*mtx);
+#else
     f32 yRotSine;
     f32 yRotCosine;
     f32 xRotSine;
@@ -464,6 +508,7 @@ void mtxf_from_transform(MtxF *mtx, ObjectTransform *trans) {
     (*mtx)[3][1] = trans->y_position;
     (*mtx)[3][2] = trans->z_position;
     (*mtx)[3][3] = 1.0f;
+#endif
 }
 
 /**
@@ -490,6 +535,22 @@ void mtxf_translate_y(MtxF *input, f32 offset) {
     (*input)[3][2] += (*input)[1][2] * offset;
 }
 
+#ifdef TARGET_DC
+void xmtrx_init_inverse_transform(ObjectTransform *trans) {
+    shz_xmtrx_init_rotation_zxy(trans->rotation.z_rotation / SHZ_FSCA_RAD_FACTOR,
+                                trans->rotation.x_rotation / SHZ_FSCA_RAD_FACTOR,
+                                trans->rotation.y_rotation / SHZ_FSCA_RAD_FACTOR);
+    shz_xmtrx_translate(trans->x_position, trans->y_position, trans->z_position);
+}
+
+void xmtrx_apply_inverse_transform(ObjectTransform *trans) {
+    shz_xmtrx_apply_rotation_zxy(trans->rotation.z_rotation / SHZ_FSCA_RAD_FACTOR,
+                                 trans->rotation.x_rotation / SHZ_FSCA_RAD_FACTOR,
+                                 trans->rotation.y_rotation / SHZ_FSCA_RAD_FACTOR);
+    shz_xmtrx_translate(trans->x_position, trans->y_position, trans->z_position);
+}
+#endif
+
 /**
  * Writes an inverse transformation matrix to `mtx` based on a pre-inverted `ObjectTransform`.
  * This is used to convert world-space coordinates to local object-space coordinates.
@@ -507,6 +568,10 @@ void mtxf_translate_y(MtxF *input, f32 offset) {
  * Official Name: mathRpyXyzMtx
  */
 void mtxf_from_inverse_transform(MtxF *mtx, ObjectTransform *trans) {
+#ifdef TARGET_DC
+    xmtrx_init_inverse_transform(trans);
+    shz_xmtrx_store_4x4((shz_mat4x4_t*)*mtx);
+#else
     f32 yRotSine;
     f32 yRotCosine;
     f32 xRotSine;
@@ -540,6 +605,7 @@ void mtxf_from_inverse_transform(MtxF *mtx, ObjectTransform *trans) {
     (*mtx)[3][2] =
         ((*mtx)[0][2] * trans->x_position) + ((*mtx)[1][2] * trans->y_position) + ((*mtx)[2][2] * trans->z_position);
     (*mtx)[3][3] = 1.0f;
+#endif
 }
 
 /**
@@ -552,6 +618,12 @@ void mtxf_from_inverse_transform(MtxF *mtx, ObjectTransform *trans) {
  * while preserving their upright orientation.
  */
 void mtxf_billboard(MtxF *mtx, s32 angle, f32 scale, f32 scaleY) {
+#ifdef TARGET_DC
+    shz_xmtrx_init_scale(scale, scale, scale);
+    shz_xmtrx_apply_rotation_z(angle / SHZ_FSCA_RAD_FACTOR);
+    shz_xmtrx_store_4x4((shz_mat4x4_t*)*mtx);
+    (*mtx)[1][1] *= scaleY;
+#else
     f32 cosine, sine;
 
     sine = sins_s16(angle) * (1.0f / 0x10000);
@@ -572,6 +644,7 @@ void mtxf_billboard(MtxF *mtx, s32 angle, f32 scale, f32 scaleY) {
     (*mtx)[3][1] = 0;
     (*mtx)[3][2] = 0;
     (*mtx)[3][3] = 1.0f;
+#endif
 }
 
 /**
@@ -745,6 +818,9 @@ s32 tri2d_xz_contains_point(s32 x, s32 z, Vec3s *pointA, Vec3s *pointB, Vec3s *p
  * Official Name: mathTranslateMtx
  */
 void mtxf_from_translation(MtxF *mtx, f32 x, f32 y, f32 z) {
+#ifdef TARGET_DC
+    shz_mat4x4_init_translation((shz_mat4x4_t*)mtx, x, y, z);
+#else
     s32 i, j;
 
     // Clear matrix
@@ -760,6 +836,7 @@ void mtxf_from_translation(MtxF *mtx, f32 x, f32 y, f32 z) {
     (*mtx)[3][0] = x;
     (*mtx)[3][1] = y;
     (*mtx)[3][2] = z;
+#endif
 }
 
 /**
@@ -767,6 +844,9 @@ void mtxf_from_translation(MtxF *mtx, f32 x, f32 y, f32 z) {
  * Official Name: mathScaleMtx
  */
 void mtxf_from_scale(MtxF *mtx, f32 scaleX, f32 scaleY, f32 scaleZ) {
+#ifdef TARGET_DC
+    shz_mat4x4_init_scale((shz_mat4x4_t*)mtx, scaleX, scaleY, scaleZ);
+#else
     s32 i, j;
 
     // Clear matrix
@@ -780,6 +860,7 @@ void mtxf_from_scale(MtxF *mtx, f32 scaleX, f32 scaleY, f32 scaleZ) {
     (*mtx)[1][1] = scaleY;
     (*mtx)[2][2] = scaleZ;
     (*mtx)[3][3] = 1.0f;
+#endif
 }
 
 #ifndef TARGET_DC
@@ -941,6 +1022,17 @@ f32 area_triangle_2d(f32 x0, f32 z0, f32 x1, f32 z1, f32 x2, f32 z2) {
     f32 dz1 = z2 - z1;
     f32 dx2 = x0 - x2;
     f32 dz2 = z0 - z2;
+#if 0
+    f32 d0 = shz_sqrtf((dx0 * dx0) + (dz0 * dz0)); // Distance between points 0 & 1
+    f32 d1 = shz_sqrtf((dx1 * dx1) + (dz1 * dz1)); // Distance between points 1 & 2
+    f32 d2 = shz_sqrtf((dx2 * dx2) + (dz2 * dz2)); // Distance between points 2 & 0
+    f32 m = 0.5f * (d0 + d1 + d2);             // Half the sum of the distances?
+    f32 result = m * (m - d0) * (m - d1) * (m - d2);
+    if (result <= 0.0f) {
+        return 0.0f;
+    }
+    return shz_sqrtf_fsrra(result);
+#else
     f32 d0 = sqrtf((dx0 * dx0) + (dz0 * dz0)); // Distance between points 0 & 1
     f32 d1 = sqrtf((dx1 * dx1) + (dz1 * dz1)); // Distance between points 1 & 2
     f32 d2 = sqrtf((dx2 * dx2) + (dz2 * dz2)); // Distance between points 2 & 0
@@ -950,11 +1042,16 @@ f32 area_triangle_2d(f32 x0, f32 z0, f32 x1, f32 z1, f32 x2, f32 z2) {
         result = 0.0f;
     }
     return sqrtf(result);
+#endif
 }
 
 void dmacopy_doubleword(void *src, void *dst, u32 end) {
     s32 size = end - (u32) dst;
+#ifdef TARGET_DC
+    shz_memcpy(dst, src, size);
+#else
     memcpy(dst, src, size);
+#endif
 }
 
 /**

--- a/src/hasm/obj_shade_fast.c
+++ b/src/hasm/obj_shade_fast.c
@@ -10,6 +10,10 @@
 #include "textures_sprites.h"
 #include "types.h"
 
+#ifdef TARGET_DC
+#   include <sh4zam/shz_sh4zam.h>
+#endif
+
 /**
  * Shade an object's vertices from its shadow light direction, without
  * rotating the light into object space first (the direction is used as-is).
@@ -19,32 +23,62 @@
  * only consumed if the batch is environment-mapped.
  */
 void obj_shade_fast(ObjectModel *model, Object *obj, f32 intensity) {
-    s32 shade;
-    s32 base;
     s16 normIdx;
     s16 i;
     s16 j;
-    s32 dirX, dirY, dirZ;
     Vertex *vertices;
     Vec3s *normals;
     ShadeProperties *shading;
+#ifdef TARGET_DC
+    f32 dirXf, dirYf, dirZf;
+    f32 baseF;
+    f32 scale;
+#else
+    s32 shade;
+    s32 base;
+    s32 dirX, dirY, dirZ;
+#endif
 
     shading = obj->shading;
     if (shading == NULL) {
         return;
     }
 
+#ifdef TARGET_DC
+    dirXf = (f32) shading->shadowDirX;
+    dirYf = (f32) shading->shadowDirY;
+    dirZf = (f32) shading->shadowDirZ;
+    baseF = shading->unk0 * intensity * 160.0f;
+    scale = baseF / 134217728.0f; /* 2^27 == 2^(11+16), combining the >>11 and >>16 from the original chain */
+#else
     dirX = shading->shadowDirX;
     dirY = shading->shadowDirY;
     dirZ = shading->shadowDirZ;
+    base = shading->unk0 * intensity * 160.0f;
+#endif
     vertices = obj->curVertData;
     normals = model->normals;
     normIdx = 0;
-    base = shading->unk0 * intensity * 160.0f;
 
     for (i = 0; i < model->numberOfBatches; i++) {
         if (model->batches[i].miscData != BATCH_VTX_COL) {
             for (j = model->batches[i].verticesOffset; j < model->batches[i + 1].verticesOffset; j++) {
+#ifdef TARGET_DC
+                f32 dot = shz_dot6f((f32) normals[normIdx].x, (f32) normals[normIdx].y, (f32) normals[normIdx].z,
+                                    dirXf, dirYf, dirZf);
+                f32 shadeF;
+                if (dot > 0.0f) {
+                    shadeF = dot * scale + baseF;
+                    if (shadeF > 255.0f) {
+                        shadeF = 255.0f;
+                    }
+                } else {
+                    shadeF = baseF;
+                }
+                vertices[j].r = (u8) shadeF;
+                vertices[j].g = (u8) shadeF;
+                vertices[j].b = (u8) shadeF;
+#else
                 shade = (normals[normIdx].x * dirX + normals[normIdx].y * dirY + normals[normIdx].z * dirZ) >> 11;
                 if (shade > 0) {
                     shade = ((shade * base) >> 16) + base;
@@ -57,6 +91,7 @@ void obj_shade_fast(ObjectModel *model, Object *obj, f32 intensity) {
                 vertices[j].r = shade;
                 vertices[j].g = shade;
                 vertices[j].b = shade;
+#endif
                 vertices[j].a = 255;
                 normIdx++;
             }
@@ -80,20 +115,42 @@ void calc_dynamic_lighting_for_object_2(Object *obj, ObjectModel *model, s16 arg
     ShadeProperties *shading;
     Vertex *vertices;
     Vec3s *normals;
-    s32 dirX, dirY, dirZ;
-    s32 ambientFactor;
-    s32 diffuseFactor;
     f32 colourBase;
-    s32 shade;
     s16 normIdx;
     s16 i;
     s16 j;
+#ifdef TARGET_DC
+    f32 ambientFactorF;
+    f32 diffuseScale;
+#else
+    s32 dirX, dirY, dirZ;
+    s32 ambientFactor;
+    s32 diffuseFactor;
+    s32 shade;
+#endif
 
     shading = obj->shading;
     if (shading == NULL) {
         return;
     }
+#ifdef TARGET_DC
+    if (arg2) {
+        shz_xmtrx_load_4x4((const shz_mat4x4_t*)get_projection_matrix_f32());
+        shz_xmtrx_apply_rotation_zxy(-obj->trans.rotation.z_rotation / SHZ_FSCA_RAD_FACTOR,
+                                     -obj->trans.rotation.x_rotation / SHZ_FSCA_RAD_FACTOR,
+                                     -obj->trans.rotation.y_rotation / SHZ_FSCA_RAD_FACTOR);
+    } else {
+        shz_xmtrx_init_rotation_zxy(-obj->trans.rotation.z_rotation / SHZ_FSCA_RAD_FACTOR,
+                                    -obj->trans.rotation.x_rotation / SHZ_FSCA_RAD_FACTOR,
+                                    -obj->trans.rotation.y_rotation / SHZ_FSCA_RAD_FACTOR);
+    }
+    shz_xmtrx_apply_scale(4.0f, 4.0f, 4.0f);
 
+    shz_vec3_deref(&direction) =
+        shz_xmtrx_transform_vec3(shz_vec3_init(shading->shadowDirX,
+                                               shading->shadowDirY,
+                                               shading->shadowDirZ));
+#else
     direction.x = shading->shadowDirX << 2;
     direction.y = shading->shadowDirY << 2;
     direction.z = shading->shadowDirZ << 2;
@@ -110,13 +167,18 @@ void calc_dynamic_lighting_for_object_2(Object *obj, ObjectModel *model, s16 arg
     trans.z_position = 0.0f;
     mtxf_from_inverse_transform(&mtx, &trans);
     mtxf_transform_dir(&mtx, &direction, &direction);
-
+#endif
     colourBase = shading->unk0 * intensity * 255.0f;
+#ifdef TARGET_DC
+    ambientFactorF = shading->ambient * colourBase;
+    diffuseScale   = (shading->diffuse * colourBase) / (8192.0f * 32768.0f);
+#else
     ambientFactor = shading->ambient * colourBase;
     diffuseFactor = shading->diffuse * colourBase;
     dirX = direction.x;
     dirY = direction.y;
     dirZ = direction.z;
+#endif
     vertices = obj->curVertData;
     normals = model->normals;
     normIdx = 0;
@@ -124,6 +186,22 @@ void calc_dynamic_lighting_for_object_2(Object *obj, ObjectModel *model, s16 arg
     for (i = 0; i < model->numberOfBatches; i++) {
         if (model->batches[i].miscData != BATCH_VTX_COL) {
             for (j = model->batches[i].verticesOffset; j < model->batches[i + 1].verticesOffset; j++) {
+#ifdef TARGET_DC
+                f32 dot = shz_dot6f((f32) normals[normIdx].x, (f32) normals[normIdx].y, (f32) normals[normIdx].z,
+                                    direction.x, direction.y, direction.z);
+                f32 shadeF;
+                if (dot > 0.0f) {
+                    shadeF = dot * diffuseScale + ambientFactorF;
+                    if (shadeF > 255.0f) {
+                        shadeF = 255.0f;
+                    }
+                } else {
+                    shadeF = ambientFactorF;
+                }
+                vertices[j].r = (u8) shadeF;
+                vertices[j].g = (u8) shadeF;
+                vertices[j].b = (u8) shadeF;
+#else
                 shade = (normals[normIdx].x * dirX + normals[normIdx].y * dirY + normals[normIdx].z * dirZ) >> 7;
                 if (shade > 0) {
                     shade = ((shade * diffuseFactor) >> 21) + ambientFactor;
@@ -136,6 +214,7 @@ void calc_dynamic_lighting_for_object_2(Object *obj, ObjectModel *model, s16 arg
                 vertices[j].r = shade;
                 vertices[j].g = shade;
                 vertices[j].b = shade;
+#endif
                 vertices[j].a = 255;
                 normIdx++;
             }

--- a/src/math_util.h
+++ b/src/math_util.h
@@ -53,6 +53,12 @@ void mtxf_mul(MtxF *mat1, MtxF *mat2, MtxF *output);
 void mtxf_to_mtx(MtxF *mf, Mtx *m);
 void vec3s_reflect(Vec3s *vec, Vec3s *n);
 void mtxs_transform_dir(MtxS *mi, Vec3s *vec);
+#ifdef TARGET_DC
+void xmtrx_init_transform(ObjectTransform* trans);
+void xmtrx_apply_transform(ObjectTransform* trans);
+void xmtrx_init_inverse_transform(ObjectTransform *trans);
+void xmtrx_apply_inverse_transform(ObjectTransform* trans);
+#endif
 void mtxf_from_transform(MtxF *mtx, ObjectTransform *trans);
 void mtxf_scale_y(MtxF *input, f32 scale);
 void mtxf_translate_y(MtxF *input, f32 offset);

--- a/src/objects.c
+++ b/src/objects.c
@@ -41,6 +41,10 @@
 #include "weather.h"
 #include "pc_swap.h"
 
+#ifdef TARGET_DC
+#   include <sh4zam/shz_sh4zam.h>
+#endif
+
 #define OBJECT_MAP_SIZE 0x3000
 #define MAX_CHECKPOINTS 60
 #define OBJECT_POOL_SIZE 0x15800
@@ -59,6 +63,7 @@
 #define SET_SHIFT_AND_MASK(varShift, varMask, x) \
     varShift = x;                                \
     varMask = 0xFFFF >> x;
+
 
 /************ .data ************/
 
@@ -5421,7 +5426,6 @@ void obj_collision_transform(Object *obj) {
 #ifdef AVOID_UB
     curMtx = &colData->matrices[colData->mtxFlip];
 #else
-
     curMtx = (MtxF *) &colData->_matrices[colData->mtxFlip << 1];
 #endif
     trans.rotation.y_rotation = -obj->trans.rotation.y_rotation;
@@ -5431,6 +5435,12 @@ void obj_collision_transform(Object *obj) {
     trans.x_position = -obj->trans.x_position;
     trans.y_position = -obj->trans.y_position;
     trans.z_position = -obj->trans.z_position;
+#ifdef TARGET_DC
+    inverseScale = shz_invf_fsrra(obj->trans.scale);
+    shz_xmtrx_init_scale(inverseScale, inverseScale, inverseScale);
+    xmtrx_apply_inverse_transform(&trans);
+    shz_xmtrx_store_4x4((shz_mat4x4_t*)curMtx);
+#else
     mtxf_from_inverse_transform(curMtx, &trans);
     inverseScale = 1.0 / obj->trans.scale;
     i = 0;
@@ -5444,10 +5454,11 @@ void obj_collision_transform(Object *obj) {
     inverseMtx[2][2] = inverseScale;
     inverseMtx[3][3] = 1.0f;
     mtxf_mul(curMtx, &inverseMtx, curMtx);
+#endif
+    trans.scale = obj->trans.scale;
     trans.rotation.y_rotation = obj->trans.rotation.y_rotation;
     trans.rotation.x_rotation = obj->trans.rotation.x_rotation;
     trans.rotation.z_rotation = obj->trans.rotation.z_rotation;
-    trans.scale = 1.0 / inverseScale;
     trans.x_position = obj->trans.x_position;
     trans.y_position = obj->trans.y_position;
     trans.z_position = obj->trans.z_position;
@@ -5541,22 +5552,41 @@ s32 collision_objectmodel(Object *obj, s32 arg1, s32 *arg2, Vec3f *arg3, f32 *ar
         spDC = (MtxF *) &collision->_matrices[((sp158->collisionData->mtxFlip + 1) & 1) << 1];
 #endif
 
+#ifdef TARGET_DC
+        shz_xmtrx_load_4x4((const shz_mat4x4_t*)*spDC);
+#endif
+
         sp14C = func_8001790C(obj, sp158);
         if (sp14C != NULL) {
             for (i = 0, j = 0; j < arg1; j++, i += 3) {
                 sp13C[j] = sp14C->unk0C[i + 0];
                 sp12C[j] = sp14C->unk0C[i + 1];
                 sp11C[j] = sp14C->unk0C[i + 2];
+#ifdef TARGET_DC
+                shz_vec3_t out = shz_xmtrx_transform_point3(shz_vec3_deref(&arg4[i]));
+                sp100[j] = out.x; spF0[j]  = out.y; spE0[j]  = out.z;
+#else
                 mtxf_transform_point(*spDC, arg4[i], arg4[i + 1], arg4[i + 2], &sp100[j], &spF0[j], &spE0[j]);
+#endif
             }
         } else {
             for (i = 0, j = 0; j < arg1; j++, i++) {
+#ifdef TARGET_DC
+                shz_vec3_t out = shz_xmtrx_transform_point3(shz_vec3_deref(&arg3[i]));
+                sp13C[j] = out.x; sp12C[j] = out.y; sp11C[j] = out.z;
+#else
                 mtxf_transform_point(*spDC, arg3[i].x, arg3[i].y, arg3[i].z, &sp13C[j], &sp12C[j], &sp11C[j]);
+#endif
             }
         }
 
         for (i = 0, j = 0; j < arg1; j++, i += 3) {
+#ifdef TARGET_DC
+            shz_vec3_t out = shz_xmtrx_transform_point3(shz_vec3_deref(&arg4[i]));
+            sp100[j] = out.x; spF0[j]  = out.y; spE0[j]  = out.z;
+#else
             mtxf_transform_point(*spDC, arg4[i], arg4[i + 1], arg4[i + 2], &sp100[j], &spF0[j], &spE0[j]);
+#endif
         }
 
         arg2[0] = 0;
@@ -5583,6 +5613,10 @@ s32 collision_objectmodel(Object *obj, s32 arg1, s32 *arg2, Vec3f *arg3, f32 *ar
         // @fake
         if (sp158) {}
 
+#ifdef TARGET_DC
+        shz_xmtrx_load_4x4((const shz_mat4x4_t*)*spDC);
+#endif
+
         sp16C = 1;
         for (i = 0, j = 0; j < arg1; j++, i += 3, sp16C <<= 1) {
             if (sp14C != NULL) {
@@ -5591,7 +5625,11 @@ s32 collision_objectmodel(Object *obj, s32 arg1, s32 *arg2, Vec3f *arg3, f32 *ar
                 sp14C->unk0C[i + 2] = spE0[j];
             }
             if (tempv0 & sp16C) {
+#ifdef TARGET_DC
+                shz_vec3_deref(&arg4[i]) = shz_xmtrx_transform_point3(shz_vec3_init(sp100[j], spF0[j], spE0[j]));
+#else
                 mtxf_transform_point(*spDC, sp100[j], spF0[j], spE0[j], &arg4[i + 0], &arg4[i + 1], &arg4[i + 2]);
+#endif
             }
         }
 
@@ -8361,8 +8399,12 @@ void calc_env_mapping_for_object(ObjectModel *model, s16 zRot, s16 xRot, s16 yRo
     s16 maskT;
     s16 i;
     s16 j;
+#ifdef TARGET_DC
+    shz_vec3_t eyeUnit;
+#else
     s16 var_v0;
     s16 var_v1;
+#endif
 
     count = 0;
     triangles = model->triangles;
@@ -8374,9 +8416,15 @@ void calc_env_mapping_for_object(ObjectModel *model, s16 zRot, s16 xRot, s16 yRo
     objTrans.y_position = 0.0f;
     objTrans.z_position = 0.0f;
     objTrans.scale = 1.0f;
+#ifdef TARGET_DC
+    eyeUnit = shz_vec3_scale(shz_vec3_init(gEnvmapPos[0].x,
+                                           gEnvmapPos[0].y,
+                                           gEnvmapPos[0].z),
+                             1.0f / 8192.0f);
+#else
     mtxf_from_transform(&objRotMtxF32, &objTrans);
     mtxf_to_mtxs(&objRotMtxF32, &objRotMtxS32);
-
+#endif
     for (i = 0; i < model->numberOfBatches; i++) {
         if (model->batches[i].flags & RENDER_ENVMAP) {
             sp70 = ((model->batches[i].flags & RENDER_UNK_0020000) | RENDER_ENVMAP) ^ RENDER_ENVMAP;
@@ -8412,15 +8460,45 @@ void calc_env_mapping_for_object(ObjectModel *model, s16 zRot, s16 xRot, s16 yRo
                     break;
             }
 
+#ifdef TARGET_DC
+            xmtrx_init_transform(&objTrans);
+            if (sp70 != 0) {
+                shz_xmtrx_apply_scale(4.0f, 4.0f, 4.0f);
+                shz_xmtrx_set_translation(32768.0f, 32768.0f, 32768.0f);
+            }
+#endif
+
             for (j = model->batches[i].verticesOffset; j < model->batches[i + 1].verticesOffset; j++, k++) {
+#ifdef TARGET_DC
+                shz_vec3_t n = shz_vec3_init(model40Entries[count].x,
+                                             model40Entries[count].y,
+                                             model40Entries[count].z);
+                s32 u16;
+                s32 v16;
+
+                if (sp70 == 0) {
+                    shz_vec3_t worldN = shz_xmtrx_transform_vec3(n);
+                    shz_vec3_t unitN  = shz_vec3_scale(worldN, 1.0f / 8192.0f);
+                    shz_vec3_t refl   = shz_vec3_reflect(eyeUnit, unitN);
+                    u16 = (s32) (refl.x * 32768.0f + 32768.0f);
+                    v16 = (s32) (refl.y * 32768.0f + 32768.0f);
+                } else {
+                    shz_vec3_t uv = shz_xmtrx_transform_point3(n);
+                    u16 = (s32) uv.x;
+                    v16 = (s32) uv.y;
+                }
+                count++;
+                D_8011AF68[k].u = ((s16) u16 >> shiftS) & maskS;
+                D_8011AF68[k].v = ((s16) v16 >> shiftT) & maskT;
+#else
                 gEnvmapPos[1].x = model40Entries[count].x;
                 gEnvmapPos[1].y = model40Entries[count].y;
                 gEnvmapPos[1].z = model40Entries[count].z;
-                count++;
                 mtxs_transform_dir(&objRotMtxS32, &gEnvmapPos[1]);
                 if (sp70 == 0) {
                     vec3s_reflect(&gEnvmapPos[0], &gEnvmapPos[1]);
                 }
+                count++;
                 var_v0 = gEnvmapPos[1].x;
                 var_v1 = gEnvmapPos[1].y;
                 if (var_v0 > 0) {
@@ -8433,6 +8511,7 @@ void calc_env_mapping_for_object(ObjectModel *model, s16 zRot, s16 xRot, s16 yRo
                 var_v1 = (var_v1 << 2) + 0x8000;
                 D_8011AF68[k].u = (var_v0 >> shiftS) & maskS;
                 D_8011AF68[k].v = (var_v1 >> shiftT) & maskT;
+#endif
             }
 
             for (j = model->batches[i].facesOffset; j < model->batches[i + 1].facesOffset; j++) {

--- a/src/racer.c
+++ b/src/racer.c
@@ -3710,7 +3710,7 @@ void func_8004CC20(s32 updateRate, f32 updateRateF, Object *racerObj, Object_Rac
     s32 steerAngle;
     f32 temp4;
     f32 var_f0;
-    f32 mtx[4][4];
+    alignas(8) f32 mtx[4][4];
     Object *obj;
     f32 var_f2;
     s8 objectMoved;


### PR DESCRIPTION

1) dreamcast/audio.c
    - Loading audio from ringbuffers to SRAM using the SQs now rather
      than shz_memcpy().
    - We are no longer deinterleaving when we are given another buffer
      from the RSP code, since it's never getting interleaved to begin
      with.
2) dreamcast/audio_hle.c
    - SHZ_FORCE_INLINE added to a bunch of tiny little shits, so I could
      use SHZ_COLD without worrying about full function calls to them.
    - op_interleave(): no longer interleaves anything, and copies both
      buffers separately.
    -  op_envmixer()
       * Decent-sized gainz from a new trick where we avoid extra clamping
         and conditionals for handling nonzero rates.
       * Loop unrolled and and prefetched for more gainz.
    - op_polef()
       * completely moved to FP math for SH4ZAM vectorization
       * loops now unrolled
       * strategic prefetching
       ! Gainz of about 1.5x.
3) src/audio.c
    - aligned heapstack buffer for better memcpy() perf.
4) src/hasm/collision.c
    - SH4ZAM-ified and batched up all transform using XMTRX.
5) src/hasm/math_util.c/.h
    - point and vec3 * mat4 transforms forward to SH4ZAM.
    - new public XMTRX init/apply routines for doing transform work
      within XMTRX regs and not round-tripping to memory.
    - mtxf routines have all been SH4ZAM'd through XMTRX.
    - dmacopy_doubleword() now using shz_memcpy()
6) src/hasm/obj_shade_fast.c
    - obj_shade_fast(): SH4ZAM'd up for faster fast versions of
      lighting.
    - calc_dynamic_lighting_for_object_2(): SH4ZAM'd up more precise
      lighting model for big-dick characters and single-player models.
7) src/objects.c
    - obj_collision_transform(): SH4ZAM'd up calculating and updating
      transform matrix.
    - Batched up all collision geometry/vertex transformations with
      SH4ZAM and keeping shit in XMTRX, while using FTRV.
    - calc_env_mapping_for_object(): SH4ZAM'd up environment mapping
      logic, moving to floating-point math, prepopulating XMTRX then
      using FTRV for each point to env map.
8) racer.c
    - Fixed a cash where a local 4x4 float matrix declared as a C array
      didn't have proper alignment but was getting used with SH4ZAM's
      shz_mat4x4_mult(), causing SH4 to shit the bed.